### PR TITLE
Add GitHub stats to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
+# About Me
 - 👋 Hi, I’m Ugur Emre Dogan
 - 👀 I’m interested in Machine Learning, Computer Vision, IoT, frontend and backend but also I am experienced in automation with Terraform, Concourse, Docker especially on AWS.
 - 🌱 I’m a Software Engineer @ResMed.
 - 💞️ I’m looking to collaborate on any project which helps people to live in a better place.
 - 🎓 I have a master's degree in Electrical and Computer Engineering from SDSU.
 
+# GitHub Stats
+![](https://github-readme-stats.vercel.app/api?username=ued094&theme=dark&hide_border=true&include_all_commits=false&count_private=true)<br/>
+![](https://nirzak-streak-stats.vercel.app/?user=ued094&theme=dark&hide_border=true)<br/>
+![](https://github-readme-stats.vercel.app/api/top-langs/?username=ued094&theme=dark&hide_border=true&include_all_commits=false&count_private=true&layout=compact)
 
 <!---
 UED094/UED094 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.


### PR DESCRIPTION
This PR adds ![GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats) to the profile README. The goal is to provide a quick overview of contributions and activity, while keeping the profile clean and professional.

- Added GitHub Stats card
- Added streaks card
- Added top languages card
- Maintained consistent styling with the existing "About Me" section

Potential future additions:
- Tech stack badges (languages, frameworks, tools)
- Social links (LinkedIn, personal site, etc.)